### PR TITLE
Add a file extension when uploading to S3

### DIFF
--- a/Captured/S3Uploader.swift
+++ b/Captured/S3Uploader.swift
@@ -63,8 +63,11 @@ class S3Uploader: Uploader {
 
   func upload(path: String) -> Bool {
     let bodyDigest = FileHash.sha256HashOfFileAtPath(path)!
-    let fileExt = NSURL(fileURLWithPath: path).pathExtension!
-    let resourcePath = "/\(randomStringWithLength(fileNameLength!)).\(fileExt)"
+    var fileExt = NSURL(fileURLWithPath: path).pathExtension!
+    if !fileExt.isEmpty {
+      fileExt = ".\(fileExt)"
+    }
+    let resourcePath = "/\(randomStringWithLength(fileNameLength!))\(fileExt)"
     let url = NSURL(string: "http://\(bucketName!).s3.amazonaws.com\(resourcePath)")!
     let request = NSMutableURLRequest(URL: url)
     let fileStream = NSInputStream(fileAtPath: path)!


### PR DESCRIPTION
I was uploading a .zip (via drag-n-drop to the menu extra) and getting a url that looked like this:

```
http://capturedeu.s3.amazonaws.com/oA3PyZiQ
```

But what I wanted was a url like this:

```
http://capturedeu.s3.amazonaws.com/oA3PyZiQ.zip
```

So this change inspects the path to the current file and will grab the file extension from that string and add it to the uploaded file. The actual file names are sill random generated strings.
