### PR TITLE
Add a CONTRIBUTING document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing
+
+Interested in hacking on Captured? Awesome. Below is an outline of how our
+process works.
+
+Please note we have a code of conduct, please follow it in all your
+interactions with the project.
+
+## Contributions Under MIT License
+
+Whenever you make a contribution to Captured, you license your contribution
+under the same terms, and you agree that you have the right to license your
+contribution under those terms. See the [GitHub TOS][ghtos] or
+[LICENSE][license] for details.
+
+## Pull Request Process
+
+## Contributing a feature
+
+In order to contribute a feature to Captured you'll need to go through the
+following steps:
+
+*   If you'd like to propose an idea, or have discussed in detail with the
+    maintainers, [create a GitHub issue](ghissue) to track the
+    discussion.  The issue should include information about the requirements
+    and use cases that it is trying to address. Include a discussion of the
+    proposed design and technical details of the implementation in the issue.
+*   We care about commit messages, [A Note About Git Commit Messages][commit]
+    covers the details.
+*   Submit a [Pull Request][ghpr] to with your code changes.
+
+*Note that we prefer bite-sized PRs instead of giant monster PRs. It's therefore
+preferable if you can introduce large features in small, individually-reviewable
+PRs that build on top of one another.*
+
+If you would like to skip the process of submitting an issue and instead would
+prefer to just submit a pull request with your desired code changes then that's
+fine. But keep in mind that there is no guarantee of it being accepted and so it
+is usually best to get agreement on the idea/design before time is spent coding
+it. However, sometimes seeing the exact code change can help focus discussions,
+so the choice is up to you.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at team@capturedapp.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/
+[ghtos]: https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
+[license]: /LICENSE
+[semver]: http://semver.org/
+[ghissue]: https://github.com/csexton/captured-mac/issues/new
+[ghpr]: https://github.com/csexton/captured-mac/pulls/new
+[commit]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/README.md
+++ b/README.md
@@ -4,22 +4,27 @@
 
 Screen Capture Sharing for Mac
 
+Interested in contributing? Awesome. You'll wanna start out at
+[CONTRIBUTING](/CONTRIBUTING.md).
+
 ## Building
 
-Captured uses [SwiftLint](https://github.com/realm/SwiftLint) as part of the build step, so you need to have that installed. If you are using homebrew:
+Captured uses [SwiftLint](https://github.com/realm/SwiftLint) as part of the
+build step, so you need to have that installed. If you are using homebrew:
 
 ```
 brew install swiftlint
 ```
 
-## Build a pre-release
+### Code Signing
 
-To create a pre-release use the `Package` target, which will build and tar and gzip everything. This `.tar.gz` file can then be shared with beta testers. There is a `make upload` task that can be run from the command line that will `scp` the file to the captured web server.
+TODO
 
-## Build for the App Store
+### Carthage
 
-TODO: Describe this one.
+TODO
 
 ## License
 
-This repo is MIT License unless otherwise noted. See [LICENSE](LICENSE) for details.
+This repo is Licensed under the MIT License unless otherwise noted. See
+[LICENSE](LICENSE) for details.


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/16963/45646078-55a90f80-ba90-11e8-9d88-62f35c4b2da2.png)


I've been working on this project for nearly a decade. So, now that I am finally freeing the source I want to make sure to do things as best as I can. Contribution guide and a CoC help achieve that.

Much of this is based on [Knative's CONTRIBUTING][1] document along with the [Contributor Covenant CoC][2].

I went with this because @bobcatfish suggested it in her [amazing talk at Devops Days][3], and overall liked the tone and guidance it provided.

[1]: https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md
[2]: http://contributor-covenant.org/version/1/4/
[3]: https://docs.google.com/presentation/d/1O44ZytTXQ9DleDXgGqtzUXbCkt9czYmuPpbVnRH38XM/edit